### PR TITLE
make operator methods' name more generic

### DIFF
--- a/provider/from/awsiamuser/provider.go
+++ b/provider/from/awsiamuser/provider.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 // fromprovider.Provider
-type AWSIAMUser struct {}
+type AWSIAMUser struct{}
 
 func (u *AWSIAMUser) Name() string {
 	return name
@@ -70,7 +70,7 @@ func (s *Spec) buildClient(ctx context.Context) (IAMAccessKeyAPI, error) {
 	return iam.NewFromConfig(cfg), nil
 }
 
-func (s *Spec) RenewKey(ctx context.Context) (secrets.Secrets, error) {
+func (s *Spec) Do(ctx context.Context) (secrets.Secrets, error) {
 	client, err := s.buildClient(ctx)
 	if err != nil {
 		return nil, err
@@ -125,7 +125,7 @@ func (s *Spec) RenewKey(ctx context.Context) (secrets.Secrets, error) {
 	}, nil
 }
 
-func (s *Spec) DeleteKey(ctx context.Context) error {
+func (s *Spec) Cleanup(ctx context.Context) error {
 	client, err := s.buildClient(ctx)
 	if err != nil {
 		return err

--- a/provider/from/awsiamuser/provider_test.go
+++ b/provider/from/awsiamuser/provider_test.go
@@ -16,7 +16,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func TestSpec_RenewKey(t *testing.T) {
+func TestSpec_Do(t *testing.T) {
 	type fields struct {
 		AccountID           string
 		Username            string
@@ -122,13 +122,13 @@ func TestSpec_RenewKey(t *testing.T) {
 				Logger:     nullLogger,
 			}
 			ctx := context.Background()
-			got, err := s.RenewKey(ctx)
+			got, err := s.Do(ctx)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Spec.RenewKey() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Spec.Do() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				fmt.Println(got)
-				t.Errorf("Spec.RenewKey() = %v, want %v", got, tt.want)
+				t.Errorf("Spec.Do() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/provider/from/mocks/provider.go
+++ b/provider/from/mocks/provider.go
@@ -88,31 +88,31 @@ func (m *MockOperator) EXPECT() *MockOperatorMockRecorder {
 	return m.recorder
 }
 
-// DeleteKey mocks base method.
-func (m *MockOperator) DeleteKey(ctx context.Context) error {
+// Cleanup mocks base method.
+func (m *MockOperator) Cleanup(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteKey", ctx)
+	ret := m.ctrl.Call(m, "Cleanup", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteKey indicates an expected call of DeleteKey.
-func (mr *MockOperatorMockRecorder) DeleteKey(ctx interface{}) *gomock.Call {
+// Cleanup indicates an expected call of Cleanup.
+func (mr *MockOperatorMockRecorder) Cleanup(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteKey", reflect.TypeOf((*MockOperator)(nil).DeleteKey), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockOperator)(nil).Cleanup), ctx)
 }
 
-// RenewKey mocks base method.
-func (m *MockOperator) RenewKey(ctx context.Context) (secrets.Secrets, error) {
+// Do mocks base method.
+func (m *MockOperator) Do(ctx context.Context) (secrets.Secrets, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RenewKey", ctx)
+	ret := m.ctrl.Call(m, "Do", ctx)
 	ret0, _ := ret[0].(secrets.Secrets)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// RenewKey indicates an expected call of RenewKey.
-func (mr *MockOperatorMockRecorder) RenewKey(ctx interface{}) *gomock.Call {
+// Do indicates an expected call of Do.
+func (mr *MockOperatorMockRecorder) Do(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenewKey", reflect.TypeOf((*MockOperator)(nil).RenewKey), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Do", reflect.TypeOf((*MockOperator)(nil).Do), ctx)
 }

--- a/provider/from/provider.go
+++ b/provider/from/provider.go
@@ -25,6 +25,6 @@ type Provider interface {
 }
 
 type Operator interface {
-	RenewKey(ctx context.Context) (secrets.Secrets, error)
-	DeleteKey(ctx context.Context) error
+	Do(ctx context.Context) (secrets.Secrets, error)
+	Cleanup(ctx context.Context) error
 }

--- a/provider/to/awssharedcredentials/provider.go
+++ b/provider/to/awssharedcredentials/provider.go
@@ -53,8 +53,8 @@ type Spec struct {
 	Logger  log.FieldLogger
 }
 
-// UpdateSecret implements toprovider.Operator interface
-func (s *Spec) UpdateSecret(ctx context.Context) error {
+// Do implements toprovider.Operator interface
+func (s *Spec) Do(ctx context.Context) error {
 	c, err := ini.Load(s.Path)
 	if err != nil {
 		return err

--- a/provider/to/circleci/provider.go
+++ b/provider/to/circleci/provider.go
@@ -76,8 +76,8 @@ func (s *Spec) buildClient() (*circleci.Client, error) {
 	return client, nil
 }
 
-// UpdateSecret implements toprovider.Operator interface
-func (s *Spec) UpdateSecret(ctx context.Context) error {
+// Do implements toprovider.Operator interface
+func (s *Spec) Do(ctx context.Context) error {
 	api, err := s.buildClient()
 	if err != nil {
 		return err

--- a/provider/to/mocks/provider.go
+++ b/provider/to/mocks/provider.go
@@ -87,16 +87,16 @@ func (m *MockOperator) EXPECT() *MockOperatorMockRecorder {
 	return m.recorder
 }
 
-// UpdateSecret mocks base method.
-func (m *MockOperator) UpdateSecret(ctx context.Context) error {
+// Do mocks base method.
+func (m *MockOperator) Do(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSecret", ctx)
+	ret := m.ctrl.Call(m, "Do", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateSecret indicates an expected call of UpdateSecret.
-func (mr *MockOperatorMockRecorder) UpdateSecret(ctx interface{}) *gomock.Call {
+// Do indicates an expected call of Do.
+func (mr *MockOperatorMockRecorder) Do(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecret", reflect.TypeOf((*MockOperator)(nil).UpdateSecret), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Do", reflect.TypeOf((*MockOperator)(nil).Do), ctx)
 }

--- a/provider/to/provider.go
+++ b/provider/to/provider.go
@@ -21,5 +21,5 @@ type Provider interface {
 }
 
 type Operator interface {
-	UpdateSecret(ctx context.Context) error
+	Do(ctx context.Context) error
 }

--- a/provider/to/tfe/provider.go
+++ b/provider/to/tfe/provider.go
@@ -79,8 +79,8 @@ func (s *Spec) buildClient() (*tfe.Client, error) {
 	return client, nil
 }
 
-// UpdateSecret implements toprovider.Operator interface
-func (s *Spec) UpdateSecret(ctx context.Context) error {
+// Do implements toprovider.Operator interface
+func (s *Spec) Do(ctx context.Context) error {
 	api, err := s.buildClient()
 	if err != nil {
 		return err

--- a/provider/to/tfe/provider_test.go
+++ b/provider/to/tfe/provider_test.go
@@ -29,7 +29,7 @@ func defaultWorkspaces(t *testing.T, ctrl *gomock.Controller, organization strin
 	return mock
 }
 
-func TestSpec_UpdateSecret(t *testing.T) {
+func TestSpec_Do(t *testing.T) {
 	type fields struct {
 		Organization string
 		Workspace    string
@@ -318,8 +318,8 @@ func TestSpec_UpdateSecret(t *testing.T) {
 
 			ctx := context.Background()
 
-			if err := s.UpdateSecret(ctx); (err != nil) != tt.wantErr {
-				t.Errorf("Spec.UpdateSecret() error = %v, wantErr %v", err, tt.wantErr)
+			if err := s.Do(ctx); (err != nil) != tt.wantErr {
+				t.Errorf("Spec.Do() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/runner.go
+++ b/runner.go
@@ -40,7 +40,7 @@ func (r *Runner) Run() error {
 
 		ctx := context.Background()
 
-		renewedSecrets, err := rn.From.Spec.Operator.RenewKey(ctx)
+		renewedSecrets, err := rn.From.Spec.Operator.Do(ctx)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"provider": rn.From.Provider,
@@ -56,7 +56,7 @@ func (r *Runner) Run() error {
 		ctx = secrets.WithSecrets(ctx, renewedSecrets)
 
 		for _, to := range rn.To {
-			err := to.Spec.Operator.UpdateSecret(ctx)
+			err := to.Spec.Operator.Do(ctx)
 			if err != nil {
 				log.WithFields(log.Fields{
 					"provider": to.Provider,
@@ -65,7 +65,7 @@ func (r *Runner) Run() error {
 			}
 		}
 
-		err = rn.From.Spec.DeleteKey(ctx)
+		err = rn.From.Spec.Cleanup(ctx)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"provider": rn.From.Provider,

--- a/runner_test.go
+++ b/runner_test.go
@@ -39,10 +39,10 @@ func TestRunner_Run(t *testing.T) {
 
 					mockedFromOperator := mockedfp.NewMockOperator(ctrl)
 					mockedToOperator := mockedtp.NewMockOperator(ctrl)
-					mockedFromOperator.EXPECT().RenewKey(ctx).Return(expectedSecrets, nil)
+					mockedFromOperator.EXPECT().Do(ctx).Return(expectedSecrets, nil)
 					ctx = secrets.WithSecrets(ctx, expectedSecrets)
-					mockedToOperator.EXPECT().UpdateSecret(ctx)
-					mockedFromOperator.EXPECT().DeleteKey(ctx)
+					mockedToOperator.EXPECT().Do(ctx)
+					mockedFromOperator.EXPECT().Cleanup(ctx)
 
 					rotations := []*schema.Rotation{
 						{
@@ -76,7 +76,7 @@ func TestRunner_Run(t *testing.T) {
 					expectedSecrets := secrets.Secrets{}
 
 					mockedFromOperator := mockedfp.NewMockOperator(ctrl)
-					mockedFromOperator.EXPECT().RenewKey(ctx).Return(expectedSecrets, nil)
+					mockedFromOperator.EXPECT().Do(ctx).Return(expectedSecrets, nil)
 
 					rotations := []*schema.Rotation{
 						{
@@ -102,7 +102,7 @@ func TestRunner_Run(t *testing.T) {
 					ctx := context.Background()
 
 					mockedFromOperator := mockedfp.NewMockOperator(ctrl)
-					mockedFromOperator.EXPECT().RenewKey(ctx).Return(nil, errFakeRunnerTest)
+					mockedFromOperator.EXPECT().Do(ctx).Return(nil, errFakeRunnerTest)
 
 					rotations := []*schema.Rotation{
 						{


### PR DESCRIPTION
Provider operations aren't always along with the current name. 
They should be more generic in order to cover extensive operations.