### PR TITLE
invoke cleanup inside Do func

### DIFF
--- a/provider/from/awsiamuser/provider_test.go
+++ b/provider/from/awsiamuser/provider_test.go
@@ -71,6 +71,7 @@ func TestSpec_Do(t *testing.T) {
 				MockIAMAccessKeyAPI: mock.MockIAMAccessKeyAPI{
 					ListAccessKeysAPI:  mock.NewMockListAccessKeysAPI(),
 					CreateAccessKeyAPI: mock.NewMockCreateAccessKeyAPI(),
+					DeleteAccessKeyAPI: mock.NewMockDeleteAccessKeyAPI(),
 				},
 			},
 			want: secrets.Secrets{

--- a/provider/from/mocks/provider.go
+++ b/provider/from/mocks/provider.go
@@ -88,20 +88,6 @@ func (m *MockOperator) EXPECT() *MockOperatorMockRecorder {
 	return m.recorder
 }
 
-// Cleanup mocks base method.
-func (m *MockOperator) Cleanup(ctx context.Context, dryRun bool) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Cleanup", ctx, dryRun)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Cleanup indicates an expected call of Cleanup.
-func (mr *MockOperatorMockRecorder) Cleanup(ctx, dryRun interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockOperator)(nil).Cleanup), ctx, dryRun)
-}
-
 // Do mocks base method.
 func (m *MockOperator) Do(ctx context.Context, dryRun bool) (secrets.Secrets, error) {
 	m.ctrl.T.Helper()

--- a/provider/from/provider.go
+++ b/provider/from/provider.go
@@ -27,5 +27,4 @@ type Provider interface {
 type Operator interface {
 	Summary() string
 	Do(ctx context.Context, dryRun bool) (secrets.Secrets, error)
-	Cleanup(ctx context.Context, dryRun bool) error
 }

--- a/provider/from/stdin/provider.go
+++ b/provider/from/stdin/provider.go
@@ -58,8 +58,3 @@ func (s *Spec) Do(ctx context.Context, dryRun bool) (secrets.Secrets, error) {
 		keyInput: input,
 	}, nil
 }
-
-func (s *Spec) Cleanup(ctx context.Context, dryRun bool) error {
-	// No thing to do
-	return nil
-}

--- a/runner.go
+++ b/runner.go
@@ -78,15 +78,6 @@ func (r *Runner) run(ctx context.Context, rptr *reporting.R, rn *schema.Rotation
 		}
 	})
 
-	// Ensure that the cleanup process is invoked when the provider's Do
-	// operation succeeds
-	defer func() {
-		err := rn.From.Spec.Cleanup(ctx, dryRun)
-		if err != nil {
-			rptr.Fail(err)
-		}
-	}()
-
 	for _, to := range rn.To {
 		to := to
 		rptr.Run(fmt.Sprintf("To/%s", to.Provider), func(rptr *reporting.R) {

--- a/runner_test.go
+++ b/runner_test.go
@@ -43,7 +43,6 @@ func TestRunner_Run(t *testing.T) {
 					mockedFromOperator.EXPECT().Do(ctx, true).Return(nil, nil)
 					mockedToOperator.EXPECT().Summary().Return("mocked to operator")
 					mockedToOperator.EXPECT().Do(ctx, true)
-					mockedFromOperator.EXPECT().Cleanup(ctx, true)
 
 					// actual run
 					mockedFromOperator.EXPECT().Summary().Return("mocked from operator")
@@ -55,7 +54,6 @@ func TestRunner_Run(t *testing.T) {
 					ctx = secrets.WithSecrets(ctx, expectedSecrets)
 					mockedToOperator.EXPECT().Summary().Return("mocked to operator")
 					mockedToOperator.EXPECT().Do(ctx, dryRun)
-					mockedFromOperator.EXPECT().Cleanup(ctx, dryRun)
 
 					rotations := []*schema.Rotation{
 						{
@@ -93,12 +91,10 @@ func TestRunner_Run(t *testing.T) {
 					// advance dry-run
 					mockedFromOperator.EXPECT().Summary().Return("mocked from operator")
 					mockedFromOperator.EXPECT().Do(ctx, true).Return(nil, nil)
-					mockedFromOperator.EXPECT().Cleanup(ctx, true)
 
 					// actual run
 					mockedFromOperator.EXPECT().Summary().Return("mocked from operator")
 					mockedFromOperator.EXPECT().Do(ctx, dryRun).Return(expectedSecrets, nil)
-					mockedFromOperator.EXPECT().Cleanup(ctx, dryRun)
 
 					rotations := []*schema.Rotation{
 						{
@@ -128,12 +124,10 @@ func TestRunner_Run(t *testing.T) {
 					// advance dry-run
 					mockedFromOperator.EXPECT().Summary().Return("mocked from operator")
 					mockedFromOperator.EXPECT().Do(ctx, true).Return(nil, errFakeRunnerTest)
-					mockedFromOperator.EXPECT().Cleanup(ctx, true)
 
 					// actual run
 					mockedFromOperator.EXPECT().Summary().Return("mocked from operator")
 					mockedFromOperator.EXPECT().Do(ctx, dryRun).Return(nil, errFakeRunnerTest)
-					mockedFromOperator.EXPECT().Cleanup(ctx, dryRun)
 
 					rotations := []*schema.Rotation{
 						{
@@ -173,7 +167,6 @@ func TestRunner_Run(t *testing.T) {
 					mockedToOperator1.EXPECT().Do(ctx, true).Return(errFakeRunnerTest)
 					mockedToOperator2.EXPECT().Summary().Return("mocked to operator 2")
 					mockedToOperator2.EXPECT().Do(ctx, true).Return(nil)
-					mockedFromOperator.EXPECT().Cleanup(ctx, true)
 
 					// actual run
 					mockedFromOperator.EXPECT().Summary().Return("mocked from operator")
@@ -183,7 +176,6 @@ func TestRunner_Run(t *testing.T) {
 					mockedToOperator1.EXPECT().Do(ctx, dryRun).Return(errFakeRunnerTest)
 					mockedToOperator2.EXPECT().Summary().Return("mocked to operator 2")
 					mockedToOperator2.EXPECT().Do(ctx, dryRun).Return(nil)
-					mockedFromOperator.EXPECT().Cleanup(ctx, dryRun)
 
 					rotations := []*schema.Rotation{
 						{


### PR DESCRIPTION
invoke cleanup from Do instead of runner.Run so that it has no side effects